### PR TITLE
Makefile 'install' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ DOCOPT_GO=${GOPATH}/linux_amd64/github.com/docopt/docopt-go.a
 PREFIX ?= /usr/local
 
 install: docopts
-	cp doctops docopts.sh $(PREFIX)/bin
+	cp docopts docopts.sh $(PREFIX)/bin
 
 # build 64 bits version
 docopts: docopts.go

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
 
 DOCOPT_GO=${GOPATH}/linux_amd64/github.com/docopt/docopt-go.a
 
+PREFIX ?= /usr/local
+
+install: docopts
+	cp doctops docopts.sh $(PREFIX)/bin
+
 # build 64 bits version
 docopts: docopts.go
 	go build docopts.go


### PR DESCRIPTION
I added an 'install' target for the Makefile. I think it might be useful because now it can be installed with tools like [bpkg](https://github.com/bpkg/bpkg).