### PR TITLE
Fixed install target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ docopts-OSX: docopts.go
 docopts-arm: docopts.go
 	env GOOS=linux GOARCH=arm go build -o docopts-arm docopts.go
 
-install: docopts
+install: all 
 	cp docopts docopts.sh $(PREFIX)/bin
 
 test: docopts


### PR DESCRIPTION
Inside the Makefile the install target should depends on `all`, or at least from `docopts` and `docopt-go`. Without these dependencies the target `docopt-go` is never executed.