### PR TITLE
Enable use of 'set -u'

### DIFF
--- a/docopts.sh
+++ b/docopts.sh
@@ -180,8 +180,8 @@ docopt_print_ARGS() {
 }
 
 ## main code if sourced with arguments
-if [[ "$1" == "--auto" ]] ; then
-    if [[ $2 == '-G' ]] ; then
+if [[ $# -ge 1 && "$1" == "--auto" ]] ; then
+    if [[ $# -ge 2 && $2 == '-G' ]] ; then
         shift 2
         eval "$(docopt_auto_parse -G "${BASH_SOURCE[1]}" "$@")"
     else

--- a/examples/docopts_auto_example.sh
+++ b/examples/docopts_auto_example.sh
@@ -14,6 +14,9 @@
 
 # Auto parse needs an empty line after the top comment above ^^^
 
+# docopts.sh is compatible with 'set -u'
+set -u
+
 # if docopts is in PATH no need to change it.
 PATH=..:$PATH
 


### PR DESCRIPTION
`set -u` is useful to detect coding errors where variables are unset, and is part of [unofficial strict mode](http://redsymbol.net/articles/unofficial-bash-strict-mode/) for bash.

This does affect the use of `$1` etc - this PR fixes errors in `docopts.sh` that occur when `set -u` is enabled.  The code still works without `set -u` enabled, of course.

The examples commit is optional, no need to include when merging but it might be helpful to see that it works.

Tested under bash 5.0 and 3.2.
