### PR TITLE
get binaries from official repo, close #37

### DIFF
--- a/get_docopts.sh
+++ b/get_docopts.sh
@@ -7,7 +7,7 @@
 # bash strict mode
 set -euo pipefail
 
-GIT_USER=Sylvain303
+: {GIT_USER:=docopt}
 GIT_PROJECT=docopts
 BASE_URL=https://github.com/$GIT_USER/$GIT_PROJECT/releases/download
 

--- a/get_docopts.sh
+++ b/get_docopts.sh
@@ -7,7 +7,7 @@
 # bash strict mode
 set -euo pipefail
 
-: {GIT_USER:=docopt}
+: ${GIT_USER:=docopt}
 GIT_PROJECT=docopts
 BASE_URL=https://github.com/$GIT_USER/$GIT_PROJECT/releases/download
 


### PR DESCRIPTION
`GIT_USER` is set to `docopt` by default. Setting the environment variable overrides the default.