### PR TITLE
Do not try to mangle double dash

### DIFF
--- a/docopts.go
+++ b/docopts.go
@@ -206,7 +206,7 @@ func (d *Docopts) Print_bash_global(args docopt.Opts) (error) {
     // docopt.Opts is of type map[string]interface{}
     // so value is an interface{}
     for key, value := range args {
-        if elem != "--" {
+        if key != "--" {
             if d.Mangle_key {
                 new_name, err = d.Name_mangle(key)
                 if err != nil {

--- a/docopts.go
+++ b/docopts.go
@@ -206,24 +206,26 @@ func (d *Docopts) Print_bash_global(args docopt.Opts) (error) {
     // docopt.Opts is of type map[string]interface{}
     // so value is an interface{}
     for key, value := range args {
-        if d.Mangle_key {
-            new_name, err = d.Name_mangle(key)
-            if err != nil {
-                return err
+        if elem != "--" {
+            if d.Mangle_key {
+                new_name, err = d.Name_mangle(key)
+                if err != nil {
+                    return err
+                }
+            } else {
+                new_name = key
             }
-        } else {
-            new_name = key
-        }
 
-        // test if already present in the map
-        prev_key, seen := varmap[new_name]
-        if seen {
-            return fmt.Errorf("%s: two or more elements have identically mangled names", prev_key)
-        } else {
-          varmap[new_name] = key
-        }
+            // test if already present in the map
+            prev_key, seen := varmap[new_name]
+            if seen {
+                return fmt.Errorf("%s: two or more elements have identically mangled names", prev_key)
+            } else {
+              varmap[new_name] = key
+            }
 
-        out_buf += fmt.Sprintf("%s=%s\n", new_name, To_bash(value))
+            out_buf += fmt.Sprintf("%s=%s\n", new_name, To_bash(value))
+        }
     }
 
     // final output
@@ -238,7 +240,7 @@ func (d *Docopts) Print_bash_global(args docopt.Opts) (error) {
 func (d *Docopts) Name_mangle(elem string) (string, error) {
     var v string
 
-    if elem == "-" || elem == "--" {
+    if elem == "-" {
         return "", fmt.Errorf("not supported")
     }
 


### PR DESCRIPTION
## TL;DR
This is a really minor fix to get around an issue we found when switching from python to go docopts in the handling of double-dash.  It just removes the double-dash from the publish-to-bash list.

## Description
When you have a double dash in your options (i.e. I have a terraform wrapper that looks like `terraform --platform=<platform> <command> [--] [<terraform_options>...]`) then the `[--]` gets run through `Name_mangle` and you end up with this error:
```
docopts:error: Print_bash_global:not supported
```
This is not necessarily pretty, but it just removes the `Name_mangle` call from `Print_bash_global` when the key is `--` so as to avoid this entirely.  It still handles things properly (`terraform_options` still contains the right result, in my example) it just doesn't do anything with that one command line flag (as it was intended for docopts only anyways, not for the following bash script)