### PR TITLE
optim(ci): clone `bats-core` with `--depth=1`

### DIFF
--- a/travis/get_bats-core.sh
+++ b/travis/get_bats-core.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-git clone https://github.com/bats-core/bats-core.git
+git clone https://github.com/bats-core/bats-core.git --depth=1
 cd bats-core
 sudo ./install.sh /usr/local
 


### PR DESCRIPTION
## Summary

Install `bats-core` with `git clone ... --depth=1` as an optimization

## Details

- should be a good bit faster than cloning with the whole history

## Testing

Can see CI passing on my branch [here](https://github.com/agilgur5/docopts/runs/7823182148?check_suite_focus=true) (which is built on top of #62 for CI to exist)