### PR TITLE
docs: add a `CONTRIBUTING.md` that references the dev docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# Contributing
+
+See [docs/developer.md](./docs/developer.md)


### PR DESCRIPTION
## Summary

Add a standard `CONTRIBUTING.md` file to the root that just references `docs/developer.md` for better accessibility

## Details

- `CONTRIBUTING.md` is a standard OSS convention
  - and GitHub recognizes when a `CONTRIBUTING.md` exists too and will add some buttons / prompts here and there
  - I looked for it initially when I started contributing and didn't see it, which was a bit confusing until I found `docs/developer.md`

- just point to `docs/developer.md` as that describes things already
  - this just serves so people can find the dev docs more easily