### PR TITLE
Use for loop in example with multiple values

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,10 +308,8 @@ else
     echo "--long-option-with-argument was not given"
 fi
 
-i=0
-while [[ $i -lt ${args[<argument-with-multiple-values>,#]} ]] ; do
+for (( i=0 ; i < args[<argument-with-multiple-values>,#] ; i++ )); do
     echo "$i: ${args[<argument-with-multiple-values>,$i]}"
-    i=$[$i+1]
 done
 ```
 


### PR DESCRIPTION
The last example, which uses an argument with multiple values, can be made more terse by using a `for` loop. I think this is an improvement, but whether others agree is subjective and a matter of style, so I'd understand if this change is not accepted.