### PR TITLE
Migrate to Go modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/docopt/docopts
+
+go 1.22.3
+
+require github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815 h1:bWDMxwH3px2JBh6AyO7hdCn/PkvCZXii8TGj7sbtEbQ=
+github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=


### PR DESCRIPTION
This switches to [Go modules](https://go.dev/blog/using-go-modules), which have now been the standard for dependency management in Go codebases for a while.